### PR TITLE
20% arcane for valefolk

### DIFF
--- a/units/valefolk.cfg
+++ b/units/valefolk.cfg
@@ -66,7 +66,7 @@
         impact=100
         fire=100
         cold=100
-        arcane=90
+        arcane=80
     [/resistance]
 [/movetype]
 
@@ -108,7 +108,7 @@
         impact=70
         fire=100
         cold=100
-        arcane=90
+        arcane=80
     [/resistance]
     [special_note]
         note={INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}


### PR DESCRIPTION
This PR adjusts the valefolk arcane resistances to be in line with the 1.16 humans in case mainline arcane gets changed back.